### PR TITLE
Added extended example to readme using custom hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,47 @@ n.add Hint(kind: hkUrgency, urgency: Critical)
 
 let handle = n.notify
 ```
+
+# Extended example using custom hint type 
+```nim
+# Example of sending a custom Hint type that replaces an 
+# existing notification as outlined here: 
+# https://wiki.archlinux.org/index.php/Desktop_notifications#Replace_previous_notification 
+#
+# Note that unlike replaceId, which works only when replacing a notification within a 
+# running application, this approach works across different processes, as it uses 
+# libnotify's in-built mechanism for this.  
+
+import notification
+import dbus
+import os
+
+let hint = Hint(
+    kind: hkCustom, 
+    customName:"x-canonical-private-synchronous", 
+    customValue: "some-identifier".asDbusValue)
+
+var n = initNotification(
+  appname = "someapp",
+  summary = "hello",
+  body = "I'm gonna be here a real long time...",
+  icon = "help-faq", 
+  timeout = initTimeout(30 * 1000), 
+)
+n.add(hint)
+
+discard n.notify
+
+n = initNotification(
+  appname = "someapp",
+  summary = "hello again",
+  body = "Think again!",
+  icon = "help-faq", 
+  timeout = initTimeout(5 * 1000), 
+)
+
+n.add(hint)
+
+sleep(2000)
+discard n.notify
+```


### PR DESCRIPTION
The example shows both how to construct a custom hint, as well as how this can be used for example to replace notifications. 

Note that unlike using replaceID which is (I think) only works in a running application (as determining an existing notification's replaceID between application runs / processes doesn't appear to be possible), by using the specific hint as shown in the example, we can replace a notification from different processes / runs of the same program by using `libnotify`s built-in mechanism for this.  